### PR TITLE
add generic adl wrapper

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -1,10 +1,11 @@
 import traits;
 import tensor;
+import meta;
 
 extern (C) int main() {
   import std.typetuple : AliasSeq;
 
-  static foreach (m; AliasSeq!(traits, tensor))
+  static foreach (m; AliasSeq!(traits, tensor, meta))
     static foreach (u; __traits(getUnitTests, m))
       u();
 

--- a/source/meta.d
+++ b/source/meta.d
@@ -16,3 +16,31 @@ template adl(string fun, string moduleName = __MODULE__) {
     }
   }
 }
+
+struct AdlWrapper(T, string moduleName = __MODULE__) {
+  T obj;
+  alias obj this;
+
+  auto opDispatch(string method, Args...)(Args args) {
+    return obj.adl!(method, moduleName)(args);
+  }
+}
+
+AdlWrapper!(T, moduleName) adlWrap(T, string moduleName = __MODULE__)(T obj) {
+  return AdlWrapper!(T, moduleName)(obj);
+}
+
+version(unittest) {
+  struct S {}
+  bool empty(S s) { return false; }
+  int front(S s) { return 42; }
+  void popFront(S s) {}
+}
+
+unittest {
+  import std.range: take, only;
+  import std.algorithm: equal;
+
+  S s;
+  assert(s.adlWrap.take(5).equal(only(42, 42, 42, 42, 42)));
+}


### PR DESCRIPTION
Allows ADL to be used with existing algorithms by wrapping arguments at the call site.